### PR TITLE
Render cumulative slow trees as well.

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,8 @@ function printSlowTrees(graph, factor) {
     var logLines = [],
         cumulativeLogLines = [];
 
-    var MAX_NAME_LENGTH = 30,
-        MAX_VALUE_LENGTH = 15;
+    var MAX_NAME_LENGTH = 45,
+        MAX_VALUE_LENGTH = 20;
 
     for (var i = 0; i < flatSortedTrees.length; i++) {
       var node = flatSortedTrees[i]

--- a/index.js
+++ b/index.js
@@ -102,6 +102,8 @@ function sortResults(graph) {
     return b.selfTime - a.selfTime
   })
 
+  var numTreesThatAreUsedMoreThanOnce = 0;
+
 
   for (var groupName in treesGroupedByName) {
     var group = treesGroupedByName[groupName];
@@ -113,15 +115,25 @@ function sortResults(graph) {
     group.averageSelfTime = group.totalSelfTime / group.nodes.length;
 
     groupedTrees.push(group);
+
+    if (group.nodes.length > 1) {
+      numTreesThatAreUsedMoreThanOnce += 1;
+    }
   }
 
   var flatSortedTrees = flattenedTrees.sort(function(a, b) {
     return b.selfTime - a.selfTime
   })
 
-  var groupedSortedTrees = groupedTrees.sort(function(a, b) {
-    return b.totalSelfTime - a.totalSelfTime
-  })
+  var groupedSortedTrees = [];
+
+  // Only return/show the grouped/cumaltive results if there are some trees used
+  // more than once.
+  if (numTreesThatAreUsedMoreThanOnce > 0) {
+    groupedSortedTrees = groupedTrees.sort(function(a, b) {
+      return b.totalSelfTime - a.totalSelfTime
+    })
+  }
 
   return {
     flatSortedTrees: flattenedTrees,

--- a/index.js
+++ b/index.js
@@ -2,6 +2,14 @@ function nameFromTreeNode(node) {
   return node.tree.description || node.tree.constructor.name;
 }
 
+function ellipsize(string, desiredLength) {
+  if (string.length > desiredLength) {
+    return string.slice(0, desiredLength - 3) + '...';
+  } else {
+    return string;
+  }
+}
+
 function printSlowTrees(graph, factor) {
   try {
     var allSortResults = sortResults(graph)
@@ -12,21 +20,21 @@ function printSlowTrees(graph, factor) {
     var logLines = [],
         cumulativeLogLines = [];
 
-    var MAX_NAME_LENGTH = 45,
-        MAX_VALUE_LENGTH = 20;
+    var MAX_NAME_CELL_LENGTH = 45,
+        MAX_VALUE_CELL_LENGTH = 20;
 
     for (var i = 0; i < flatSortedTrees.length; i++) {
       var node = flatSortedTrees[i]
       var name = nameFromTreeNode(node)
 
       if (node.selfTime > minimumTime) {
-        logLines.push(pad(name, MAX_NAME_LENGTH) + ' | ' + pad(Math.floor(node.selfTime / 1e6) + 'ms', MAX_VALUE_LENGTH))
+        logLines.push(pad(ellipsize(name, MAX_NAME_CELL_LENGTH), MAX_NAME_CELL_LENGTH) + ' | ' + pad(Math.floor(node.selfTime / 1e6) + 'ms', MAX_VALUE_CELL_LENGTH))
       }
     }
 
     if (logLines.length > 0) {
-      logLines.unshift(pad('', MAX_NAME_LENGTH, '-') + '-+-' + pad('', MAX_VALUE_LENGTH, '-'))
-      logLines.unshift(pad('Slowest Trees', MAX_NAME_LENGTH) + ' | ' + pad('Total', MAX_VALUE_LENGTH))
+      logLines.unshift(pad('', MAX_NAME_CELL_LENGTH, '-') + '-+-' + pad('', MAX_VALUE_CELL_LENGTH, '-'))
+      logLines.unshift(pad('Slowest Trees', MAX_NAME_CELL_LENGTH) + ' | ' + pad('Total', MAX_VALUE_CELL_LENGTH))
     }
 
     for (var i = 0; i < groupedSortedTrees.length; i++) {
@@ -40,20 +48,23 @@ function printSlowTrees(graph, factor) {
           averageStr = '';
         }
 
-        cumulativeLogLines.push(pad(group.name + ' (' + group.nodes.length + ')', MAX_NAME_LENGTH) + ' | ' + pad(Math.floor(group.totalSelfTime / 1e6) + 'ms' + averageStr, MAX_VALUE_LENGTH))
+        var countStr = ' (' + group.nodes.length + ')'
+        var nameStr = ellipsize(group.name, MAX_NAME_CELL_LENGTH - countStr.length)
+
+        cumulativeLogLines.push(pad(nameStr + countStr, MAX_NAME_CELL_LENGTH) + ' | ' + pad(Math.floor(group.totalSelfTime / 1e6) + 'ms' + averageStr, MAX_VALUE_CELL_LENGTH))
       }
     }
 
     if (cumulativeLogLines.length > 0) {
-      cumulativeLogLines.unshift(pad('', MAX_NAME_LENGTH, '-') + '-+-' + pad('', MAX_VALUE_LENGTH, '-'))
-      cumulativeLogLines.unshift(pad('Slowest Trees (cumulative)', MAX_NAME_LENGTH) + ' | ' + pad('Total (avg)', MAX_VALUE_LENGTH))
+      cumulativeLogLines.unshift(pad('', MAX_NAME_CELL_LENGTH, '-') + '-+-' + pad('', MAX_VALUE_CELL_LENGTH, '-'))
+      cumulativeLogLines.unshift(pad('Slowest Trees (cumulative)', MAX_NAME_CELL_LENGTH) + ' | ' + pad('Total (avg)', MAX_VALUE_CELL_LENGTH))
       cumulativeLogLines.unshift('\n')
     }
 
     console.log('\n' + logLines.join('\n') + cumulativeLogLines.join('\n') + '\n')
   } catch (e) {
-    console.error(e);
-    throw e;
+    console.error('Error when printing slow trees:', e);
+    console.error(e.stack)
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -30,16 +30,23 @@ function printSlowTrees(graph, factor) {
     }
 
     for (var i = 0; i < groupedSortedTrees.length; i++) {
-      var group = groupedSortedTrees[i]
+      var group = groupedSortedTrees[i],
+          averageStr
 
       if (group.totalSelfTime > minimumTime) {
-        cumulativeLogLines.push(pad(group.name + ' (' + group.nodes.length + ')', MAX_NAME_LENGTH) + ' | ' + pad(Math.floor(group.totalSelfTime / 1e6) + 'ms', MAX_VALUE_LENGTH))
+        if (group.nodes.length > 1) {
+          averageStr = ' (' + Math.floor(group.averageSelfTime / 1e6) + ' ms)';
+        } else {
+          averageStr = '';
+        }
+
+        cumulativeLogLines.push(pad(group.name + ' (' + group.nodes.length + ')', MAX_NAME_LENGTH) + ' | ' + pad(Math.floor(group.totalSelfTime / 1e6) + 'ms' + averageStr, MAX_VALUE_LENGTH))
       }
     }
 
     if (cumulativeLogLines.length > 0) {
       cumulativeLogLines.unshift(pad('', MAX_NAME_LENGTH, '-') + '-+-' + pad('', MAX_VALUE_LENGTH, '-'))
-      cumulativeLogLines.unshift(pad('Slowest Trees (cumulative)', MAX_NAME_LENGTH) + ' | ' + pad('Total', MAX_VALUE_LENGTH))
+      cumulativeLogLines.unshift(pad('Slowest Trees (cumulative)', MAX_NAME_LENGTH) + ' | ' + pad('Total (avg)', MAX_VALUE_LENGTH))
       cumulativeLogLines.unshift('\n')
     }
 
@@ -65,7 +72,8 @@ function sortResults(graph) {
       treesGroupedByName[name] = {
         name: name,
         nodes: [],
-        totalSelfTime: undefined // to calculate
+        totalSelfTime: undefined, // to calculate
+        averageSelfTime: undefined // to calculate
       }
     }
     treesGroupedByName[name].nodes.push(node)
@@ -90,6 +98,8 @@ function sortResults(graph) {
     group.totalSelfTime = group.nodes.reduce(function(sum, node) {
       return sum + node.selfTime
     }, 0);
+
+    group.averageSelfTime = group.totalSelfTime / group.nodes.length;
 
     groupedTrees.push(group);
   }

--- a/index.js
+++ b/index.js
@@ -1,32 +1,74 @@
+function nameFromTreeNode(node) {
+  return node.tree.description || node.tree.constructor.name;
+}
+
 function printSlowTrees(graph, factor) {
-  var sortedTrees = sortResults(graph)
-  var minimumTime = graph.totalTime * (factor || 0.05)
-  var logLines = []
+  try {
+    var allSortResults = sortResults(graph)
+    var flatSortedTrees = allSortResults.flatSortedTrees
+    var groupedSortedTrees = allSortResults.groupedSortedTrees
 
-  for (var i = 0; i < sortedTrees.length; i++) {
-    var node = sortedTrees[i]
-    var name = node.tree.description || node.tree.constructor.name
+    var minimumTime = graph.totalTime * (factor || 0.05)
+    var logLines = [],
+        cumulativeLogLines = [];
 
-    if (node.selfTime > minimumTime) {
-      logLines.push(pad(name, 30) + ' | ' + pad(Math.floor(node.selfTime / 1e6) + 'ms', 15))
+    var MAX_NAME_LENGTH = 30,
+        MAX_VALUE_LENGTH = 15;
+
+    for (var i = 0; i < flatSortedTrees.length; i++) {
+      var node = flatSortedTrees[i]
+      var name = nameFromTreeNode(node)
+
+      if (node.selfTime > minimumTime) {
+        logLines.push(pad(name, MAX_NAME_LENGTH) + ' | ' + pad(Math.floor(node.selfTime / 1e6) + 'ms', MAX_VALUE_LENGTH))
+      }
     }
-  }
 
-  if (logLines.length > 0) {
-    logLines.unshift(pad('', 30, '-') + '-+-' + pad('', 15, '-'))
-    logLines.unshift(pad('Slowest Trees', 30) + ' | ' + pad('Total', 15))
-  }
+    if (logLines.length > 0) {
+      logLines.unshift(pad('', MAX_NAME_LENGTH, '-') + '-+-' + pad('', MAX_VALUE_LENGTH, '-'))
+      logLines.unshift(pad('Slowest Trees', MAX_NAME_LENGTH) + ' | ' + pad('Total', MAX_VALUE_LENGTH))
+    }
 
-  console.log('\n' + logLines.join('\n') + '\n')
+    for (var i = 0; i < groupedSortedTrees.length; i++) {
+      var group = groupedSortedTrees[i]
+
+      if (group.totalSelfTime > minimumTime) {
+        cumulativeLogLines.push(pad(group.name + ' (' + group.nodes.length + ')', MAX_NAME_LENGTH) + ' | ' + pad(Math.floor(group.totalSelfTime / 1e6) + 'ms', MAX_VALUE_LENGTH))
+      }
+    }
+
+    if (cumulativeLogLines.length > 0) {
+      cumulativeLogLines.unshift(pad('', MAX_NAME_LENGTH, '-') + '-+-' + pad('', MAX_VALUE_LENGTH, '-'))
+      cumulativeLogLines.unshift(pad('Slowest Trees (cumulative)', MAX_NAME_LENGTH) + ' | ' + pad('Total', MAX_VALUE_LENGTH))
+      cumulativeLogLines.unshift('\n')
+    }
+
+    console.log('\n' + logLines.join('\n') + cumulativeLogLines.join('\n') + '\n')
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
 }
 
 function sortResults(graph) {
   var flattenedTrees = []
+  var treesGroupedByName = Object.create(null)
+  var groupedTrees = [];
 
   function process(node) {
     if (flattenedTrees.indexOf(node) > -1) { return } // for de-duping
 
     flattenedTrees.push(node)
+
+    var name = nameFromTreeNode(node)
+    if (treesGroupedByName[name] == null) {
+      treesGroupedByName[name] = {
+        name: name,
+        nodes: [],
+        totalSelfTime: undefined // to calculate
+      }
+    }
+    treesGroupedByName[name].nodes.push(node)
 
     var length = node.subtrees.length
     for (var i = 0; i < length; i++) {
@@ -34,11 +76,36 @@ function sortResults(graph) {
     }
   }
 
+
   process(graph) // kick off with the top item
 
-  return flattenedTrees.sort(function(a, b) {
+  var flatSortedTrees = flattenedTrees.sort(function(a, b) {
     return b.selfTime - a.selfTime
   })
+
+
+  for (var groupName in treesGroupedByName) {
+    var group = treesGroupedByName[groupName];
+
+    group.totalSelfTime = group.nodes.reduce(function(sum, node) {
+      return sum + node.selfTime
+    }, 0);
+
+    groupedTrees.push(group);
+  }
+
+  var flatSortedTrees = flattenedTrees.sort(function(a, b) {
+    return b.selfTime - a.selfTime
+  })
+
+  var groupedSortedTrees = groupedTrees.sort(function(a, b) {
+    return b.totalSelfTime - a.totalSelfTime
+  })
+
+  return {
+    flatSortedTrees: flattenedTrees,
+    groupedSortedTrees: groupedSortedTrees
+  }
 }
 
 function pad(str, len, char, dir) {


### PR DESCRIPTION
More specifically, sum the selfTime for all nodes with the same name. While I was here, I did a bunch of other polish stuff (longer widths, truncating names if overflow, etc). Let me know if it is too much together at once :smile:.

Example output on my giant, complex Brocfile:

```
Slowest Trees                                 | Total
----------------------------------------------+---------------------
JadeBenderFilter                              | 3050ms
BenderCompassCompiler                         | 2472ms
DelegateBuildToBrocfilesInReverseDependenc... | 1831ms
JadeBenderCustomizationsFilter                | 1192ms

Slowest Trees (cumulative)                    | Total (avg)
----------------------------------------------+---------------------
BenderCompassCompiler (47)                    | 8141ms (173 ms)
JadeBenderFilter (47)                         | 4548ms (96 ms)
JadeBenderCustomizationsFilter (47)           | 2393ms (50 ms)
TreeMerger (95)                               | 1983ms (20 ms)
CoffeeScriptFilter (47)                       | 1851ms (39 ms)
DelegateBuildToBrocfilesInReverseDepen... (1) | 1831ms
```