### PR TITLE
Use structured instrumentation

### DIFF
--- a/calculate-summary.js
+++ b/calculate-summary.js
@@ -1,0 +1,81 @@
+module.exports = calculateSummary;
+
+function byTotalSelfTime(a, b) {
+  return b.totalSelfTime - a.totalSelfTime;
+}
+
+function bySelfTime(a, b) {
+  return b.selfTime - a.selfTime;
+}
+
+function normalizeSelfTime(n) {
+  n.selfTime = n.selfTime / 1e6;
+}
+
+function normalizeTimes(n) {
+  n.averageSelfTime = n.averageSelfTime / 1e6;
+  n.totalSelfTime = n.totalSelfTime / 1e6;
+}
+
+function calculateSummary(tree) {
+  var totalTime = 0;
+  var nodes = [];
+  var groupedNodes = [];
+  var nodesGroupedByName = {};
+
+  // calculate times
+  tree.visitPostOrder(function (node) {
+    var nonbroccoliChildrenTime = node.children.reduce(function (acc, childNode) {
+      // subsume non-broccoli nodes as their ancestor broccoli nodes'
+      // broccoliSelfTime
+      if (childNode.id.broccoliNode) {
+        return acc;
+      } else {
+        return acc + childNode._slowTrees.broccoliSelfTime;
+      }
+    }, 0);
+
+    var time = nonbroccoliChildrenTime + node.stats.time.self;
+
+    node._slowTrees = { broccoliSelfTime: time };
+    totalTime += node.stats.time.self;
+
+    if (node.id.broccoliNode) {
+      nodes.push({
+        name: node.id.name,
+        selfTime: time,
+      });
+
+      if (!nodesGroupedByName[node.id.name]) {
+        nodesGroupedByName[node.id.name] = {
+          name: node.id.name,
+          count: 0,
+          averageSelfTime: 0,
+          totalSelfTime: 0,
+        };
+        groupedNodes.push(nodesGroupedByName[node.id.name]);
+      }
+
+      var group = nodesGroupedByName[node.id.name];
+      group.count++;
+      group.totalSelfTime += time;
+      group.averageSelfTime = group.totalSelfTime / group.count;
+    }
+  });
+
+  // sort nodes
+  nodes = nodes.sort(bySelfTime);
+
+  groupedNodes = groupedNodes.sort(byTotalSelfTime);
+  nodes.forEach(normalizeSelfTime);
+  groupedNodes.forEach(normalizeTimes);
+
+  // normalize times (nanosec to ms)
+  totalTime = totalTime / 1e6;
+
+  return {
+    totalTime: totalTime,
+    nodes: nodes,
+    groupedNodes: groupedNodes,
+  };
+}

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+var calculateSummary = require('./calculate-summary');
+
 function ellipsize(string, desiredLength) {
   if (string.length > desiredLength) {
     return string.slice(0, desiredLength - 3) + '...';
@@ -6,55 +8,44 @@ function ellipsize(string, desiredLength) {
   }
 }
 
-function printSlowNodes(nodeWrapper, factor) {
+module.exports = function printSlowNodes(tree, factor) {
   try {
-    var allSortResults = sortResults(nodeWrapper)
-    var flatSortedNodes = allSortResults.flatSortedNodes
-    var groupedSortedNodes = allSortResults.groupedSortedNodes
+    var summary = calculateSummary(tree);
+    var pcThreshold = factor || 0.05;
+    var msThreshold = pcThreshold * summary.totalTime;
+    var logLines = [];
+    var cumulativeLogLines = [];
 
-    var minimumTime = nodeWrapper.buildState.totalTime * (factor || 0.05)
-    var logLines = [],
-        cumulativeLogLines = [];
+    var MAX_NAME_CELL_LENGTH = 45;
+    var MAX_VALUE_CELL_LENGTH = 20;
 
-    var MAX_NAME_CELL_LENGTH = 45,
-        MAX_VALUE_CELL_LENGTH = 20;
-
-    for (var i = 0; i < flatSortedNodes.length; i++) {
-      var nw = flatSortedNodes[i]
-
-      if (nw.buildState.selfTime > minimumTime) {
-        logLines.push(pad(ellipsize(nw.label, MAX_NAME_CELL_LENGTH), MAX_NAME_CELL_LENGTH) + ' | ' + pad(Math.floor(nw.buildState.selfTime) + 'ms', MAX_VALUE_CELL_LENGTH))
-      }
-    }
 
     if (logLines.length > 0) {
-      logLines.unshift(pad('', MAX_NAME_CELL_LENGTH, '-') + '-+-' + pad('', MAX_VALUE_CELL_LENGTH, '-'))
-      logLines.unshift(pad('Slowest Nodes', MAX_NAME_CELL_LENGTH) + ' | ' + pad('Total', MAX_VALUE_CELL_LENGTH))
+      logLines.unshift(pad('', MAX_NAME_CELL_LENGTH, '-') + '-+-' + pad('', MAX_VALUE_CELL_LENGTH, '-'));
+      logLines.unshift(pad('Slowest Nodes', MAX_NAME_CELL_LENGTH) + ' | ' + pad('Total', MAX_VALUE_CELL_LENGTH));
     }
 
-    for (var i = 0; i < groupedSortedNodes.length; i++) {
-      var group = groupedSortedNodes[i],
-          averageStr
+    for (var i = 0; i < summary.groupedNodes.length; i++) {
+      var group = summary.groupedNodes[i];
+      var averageStr;
 
-      if (group.totalSelfTime > minimumTime) {
-        if (group.nodeWrappers.length > 1) {
+      if (group.totalSelfTime > msThreshold) {
+        if (group.count > 1) {
           averageStr = ' (' + Math.floor(group.averageSelfTime) + ' ms)';
         } else {
           averageStr = '';
         }
 
-        var countStr = ' (' + group.nodeWrappers.length + ')'
+        var countStr = ' (' + group.count + ')'
         var nameStr = ellipsize(group.name, MAX_NAME_CELL_LENGTH - countStr.length)
 
         cumulativeLogLines.push(pad(nameStr + countStr, MAX_NAME_CELL_LENGTH) + ' | ' + pad(Math.floor(group.totalSelfTime) + 'ms' + averageStr, MAX_VALUE_CELL_LENGTH))
       }
     }
 
-    if (cumulativeLogLines.length > 0) {
-      cumulativeLogLines.unshift(pad('', MAX_NAME_CELL_LENGTH, '-') + '-+-' + pad('', MAX_VALUE_CELL_LENGTH, '-'))
-      cumulativeLogLines.unshift(pad('Slowest Nodes (cumulative)', MAX_NAME_CELL_LENGTH) + ' | ' + pad('Total (avg)', MAX_VALUE_CELL_LENGTH))
-      cumulativeLogLines.unshift('\n')
-    }
+    cumulativeLogLines.unshift(pad('', MAX_NAME_CELL_LENGTH, '-') + '-+-' + pad('', MAX_VALUE_CELL_LENGTH, '-'))
+    cumulativeLogLines.unshift(pad('Slowest Nodes (totalTime => ' + (pcThreshold * 100) +'% )', MAX_NAME_CELL_LENGTH) + ' | ' + pad('Total (avg)', MAX_VALUE_CELL_LENGTH))
+    cumulativeLogLines.unshift('\n')
 
     console.log('\n' + logLines.join('\n') + cumulativeLogLines.join('\n') + '\n')
   } catch (e) {
@@ -63,76 +54,6 @@ function printSlowNodes(nodeWrapper, factor) {
   }
 }
 
-function sortResults(nodeWrapper) {
-  var flattenedNodes = []
-  var nodesGroupedByName = Object.create(null)
-  var groupedNodes = [];
-
-  function process(nw) {
-    if (flattenedNodes.indexOf(nw) > -1) { return } // for de-duping
-
-    flattenedNodes.push(nw)
-
-    if (nodesGroupedByName[nw.label] == null) {
-      nodesGroupedByName[nw.label] = {
-        name: nw.label,
-        nodeWrappers: [],
-        totalSelfTime: undefined, // to calculate
-        averageSelfTime: undefined // to calculate
-      }
-    }
-    nodesGroupedByName[nw.label].nodeWrappers.push(nw)
-
-    var length = nw.inputNodeWrappers.length
-    for (var i = 0; i < length; i++) {
-      process(nw.inputNodeWrappers[i])
-    }
-  }
-
-  process(nodeWrapper) // kick off with the top item
-
-  var flatSortedNodes = flattenedNodes.sort(function(a, b) {
-    return b.buildState.selfTime - a.buildState.selfTime
-  })
-
-  var numNodesThatAreUsedMoreThanOnce = 0;
-
-
-  for (var groupName in nodesGroupedByName) {
-    var group = nodesGroupedByName[groupName];
-
-    group.totalSelfTime = group.nodeWrappers.reduce(function(sum, nw) {
-      return sum + nw.buildState.selfTime
-    }, 0);
-
-    group.averageSelfTime = group.totalSelfTime / group.nodeWrappers.length;
-
-    groupedNodes.push(group);
-
-    if (group.nodeWrappers.length > 1) {
-      numNodesThatAreUsedMoreThanOnce += 1;
-    }
-  }
-
-  var flatSortedNodes = flattenedNodes.sort(function(a, b) {
-    return b.selfTime - a.selfTime
-  })
-
-  var groupedSortedNodes = [];
-
-  // Only return/show the grouped/cumulative results if there are some nodes used
-  // more than once.
-  if (numNodesThatAreUsedMoreThanOnce > 0) {
-    groupedSortedNodes = groupedNodes.sort(function(a, b) {
-      return b.totalSelfTime - a.totalSelfTime
-    })
-  }
-
-  return {
-    flatSortedNodes: flattenedNodes,
-    groupedSortedNodes: groupedSortedNodes
-  }
-}
 
 function pad(str, len, char, dir) {
   if (!char) { char = ' '}
@@ -157,4 +78,3 @@ function pad(str, len, char, dir) {
   return str
 }
 
-module.exports = printSlowNodes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "broccoli-slow-trees",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Print out of slowest trees for Broccoli.",
   "main": "index.js",
   "scripts": {
@@ -18,5 +18,18 @@
   "bugs": {
     "url": "https://github.com/rwjblue/broccoli-slow-trees/issues"
   },
-  "homepage": "https://github.com/rwjblue/broccoli-slow-trees"
+  "homepage": "https://github.com/rwjblue/broccoli-slow-trees",
+  "scripts": {
+    "test": "mocha tests/",
+    "test:debug": "mocha --no-timeouts debug tests/"
+  },
+  "dependencies": {
+    "heimdalljs": "^0.1.0"
+  },
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "chai-as-promised": "^5.1.0",
+    "chai-files": "^1.2.0",
+    "mocha": "^2.5.3"
+  }
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,0 +1,123 @@
+var chai = require('chai'), expect = chai.expect;
+var chaiAsPromised = require('chai-as-promised');
+
+var Heimdall = require('heimdalljs/heimdall');
+var calculateSummary = require('../calculate-summary');
+
+chai.use(chaiAsPromised);
+
+function stubTime(ms) {
+  process.hrtime = function () {
+    return [0, ms * 1e6];
+  };
+}
+
+var originalHrtime = process.hrtime;
+
+function restoreTime() {
+  process.hrtime = originalHrtime;
+}
+
+describe('calculateSummary', function() {
+  afterEach(restoreTime);
+
+  it('summarizes simple graphs', function() {
+    stubTime(100);
+    var heimdall = new Heimdall();
+
+    return expect(heimdall.node({ name: 'babel', broccoliNode: true, }, function () {
+      stubTime(200);
+      return heimdall.node({ name: 'merge-trees', broccoliNode: true }, function () {
+        stubTime(350);
+      });
+    }).then(function () {
+      return heimdall.node({ name: 'merge-trees', broccoliNode: true }, function () {
+        stubTime(600);
+      });
+    }).then(function () {
+      return calculateSummary(heimdall);
+    })).to.eventually.deep.equal({
+      totalTime: 500,
+      nodes: [
+        {
+          name: 'merge-trees',
+          selfTime: 250,
+        },
+        {
+          name: 'merge-trees',
+          selfTime: 150,
+        },
+        {
+          name: 'babel',
+          selfTime: 100,
+        }
+      ],
+      groupedNodes: [
+        {
+          name: 'merge-trees',
+          count: 2,
+          averageSelfTime: 200,
+          totalSelfTime: 400,
+        },
+        {
+          name: 'babel',
+          count: 1,
+          averageSelfTime: 100,
+          totalSelfTime: 100,
+        }
+      ],
+    });
+  });
+
+  it("counts non-broccoli nodes' time as part of their ancestor broccoli node's time", function() {
+    stubTime(100);
+    var heimdall = new Heimdall();
+
+    return expect(heimdall.node({ name: 'merge-trees', broccoliNode: true, }, function () {
+
+      stubTime(200);
+      return heimdall.node({ name: 'babel', broccoliNode: true }, function () {
+        stubTime(300);
+      }).then(function () {
+        return heimdall.node({ name: 'fs-tree-diff' }, function () {
+          return heimdall.node({ name: 'calculatePatch' }, function () {
+            stubTime(550);
+          }).then(function () {
+            return heimdall.node({ name: 'sortAndExpand' }, function () {
+              stubTime(600);
+            });
+          });
+        });
+      });
+
+    }).then(function () {
+      return calculateSummary(heimdall);
+    })).to.eventually.deep.equal({
+      totalTime: 500,
+      nodes: [
+        {
+          name: 'merge-trees',
+          selfTime: 400,
+        },
+        {
+          name: 'babel',
+          selfTime: 100,
+        }
+      ],
+      groupedNodes: [
+        {
+          averageSelfTime: 400,
+          count: 1,
+          name: "merge-trees",
+          totalSelfTime: 400,
+        },
+        {
+          averageSelfTime: 100,
+          count: 1,
+          name: "babel",
+          totalSelfTime: 100,
+        }
+      ],
+    });
+  });
+});


### PR DESCRIPTION
Read slow-trees information from heimdall nodes rather than having time stats
managed by broccoli directly.

Also some miscellaneous visual cleanup

  - only display cumulative
  - also display factor
  - nw.label is now nw.name

cc @stefanpenner